### PR TITLE
99 Swift Problems - Fix incorrect image reference

### DIFF
--- a/projects/99-swift-problems/index.md
+++ b/projects/99-swift-problems/index.md
@@ -3473,7 +3473,7 @@ Write a method for our `Tree` class that calculates a numbering scheme for the
 tree and returns a labeled graph. What is the solution for the larger tree
 pictured below?
 
-![](/projects/99-swift-problems/p92a.gif)
+![](/projects/99-swift-problems/p92b.gif)
 
 Implementation:
 


### PR DESCRIPTION
In problem 92, the second graph image is the same as the first. From the source, it looks like it should be `p92b.gif` instead.